### PR TITLE
FIX: add_elevation and add_azimuth broken in new netCDF release.

### DIFF
--- a/description.txt
+++ b/description.txt
@@ -1,0 +1,2 @@
+MultiDop wraps the OU DDA package and merges it to work seamlessly with
+DOE Py-ART.

--- a/multidop/angles.py
+++ b/multidop/angles.py
@@ -98,8 +98,7 @@ def add_azimuth_as_field(grid, dz_name='DT', az_name='AZ', bad=-32768):
         grid.radar_latitude['data'][0], grid.radar_longitude['data'][0],
         grid.point_latitude['data'], grid.point_longitude['data'])
     cond = np.isfinite(az)
-    az[~cond] = bad
-    az = np.ma.masked_where(az == bad, az)
+    az = np.ma.masked_invalid(az)
     grid = _add_field_to_object(grid, az, dz_name=dz_name, field_name=az_name)
     return grid
 
@@ -135,7 +134,6 @@ def add_elevation_as_field(grid, dz_name='DT', el_name='EL', bad=-32768):
         h3[i, :, :] = grid.z['data'][i] - grid.radar_altitude['data'][0]
     sr, el = rsl_get_slantr_and_elev(gr, h3/1000.0)
     cond = np.isfinite(el)
-    el[~cond] = bad
-    el = np.ma.masked_where(el == bad, el)
+    el = np.ma.masked_invalid(el)
     grid = _add_field_to_object(grid, el, dz_name=dz_name, field_name=el_name)
     return grid


### PR DESCRIPTION
The masking of the azimuth and elevation fields was broken in the new release of numpy and caused Py-ART to throw an error when writing the grid. Using numpy's ma.masked_invalid to mask out NaNs and Infs in the calculation fixed the issue.